### PR TITLE
Simplify .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,47 +2,14 @@
 node_modules/
 package-lock.json
 
-# Playwright
+# Playwright specific
 test-results/
 playwright-report/
-blob-report/
 playwright/.cache/
 
-# Environment variables
-.env
-.env.local
-.env.*.local
-
-# IDE - VSCode
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-
-# IDE - IntelliJ
-.idea/
-*.iml
-*.iws
-*.ipr
-
-# macOS
+# System files
 .DS_Store
-.AppleDouble
-.LSOverride
 
 # Logs
-logs
 *.log
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# Optional npm cache directory
-.npm
-
-# Optional eslint cache
-.eslintcache
-
-# Optional coverage directory
-coverage/ 


### PR DESCRIPTION
Remove unnecessary entries
     - Keep only essential ignores for:
       - Dependencies (node_modules, package-lock.json)
       - Playwright files (test results and cache)
       - System files (.DS_Store)
       - Log files